### PR TITLE
Add fallback chain for alias file locations

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,30 @@ Restart Pi after updating.
 
 ### Model Aliases
 
-Create `aliases.json` in the extension directory to define shortcuts:
+Model aliases can be defined in multiple locations with a priority-based fallback chain:
+
+| Level | Path | Purpose |
+|-------|------|---------|
+| 1. Project | `{project}/.pi/aliases.json` | Per-project customization, committed to repo |
+| 2. User | `~/.pi/agent/aliases.json` | Global user aliases, survives npm updates |
+| 3. Extension | `~/.pi/agent/extensions/model-switch/aliases.json` | Bundled defaults |
+
+The extension loads from **project → user → extension** in order, using the first file found.
+
+#### Example locations
 
 ```bash
+# Project-level (highest priority)
+/home/pcaro/my-project/.pi/aliases.json
+
+# User-level (middle priority)
+~/.pi/agent/aliases.json
+
+# Extension-level (lowest priority - bundled with extension)
 ~/.pi/agent/extensions/model-switch/aliases.json
 ```
+
+#### Defining aliases
 
 ```json
 {
@@ -54,6 +73,8 @@ Create `aliases.json` in the extension directory to define shortcuts:
 - **Array value**: Uses first available model in the list (fallback chain)
 
 Then just say "switch to cheap" or "use coding model".
+
+> **Tip**: Use user-level (`~/.pi/agent/aliases.json`) for your personal aliases - they won't be overwritten when updating the extension.
 
 ### AGENTS.md
 
@@ -78,7 +99,7 @@ Once installed, the agent gains a `switch_model` tool. Just ask naturally:
 - "Change to a model with vision capabilities"
 - "Use a cheaper model for this task"
 
-The agent will list models or switch as appropriate.
+The agent will list models or switch as appropriate. When aliases are loaded, the tool output shows which file they're loaded from (e.g., `Aliases: cheap, coding (from ~/.pi/agent/aliases.json)`).
 
 ## Tool Reference
 

--- a/index.ts
+++ b/index.ts
@@ -3,25 +3,44 @@ import { Type } from "@sinclair/typebox";
 import { existsSync, readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import { homedir } from "node:os";
 
 type AliasConfig = Record<string, string | string[]>;
 
-function loadAliases(extensionDir: string): { aliases: AliasConfig; error?: string } {
-	const aliasPath = join(extensionDir, "aliases.json");
-	if (!existsSync(aliasPath)) {
-		return { aliases: {} };
+/**
+ * Alias file locations in priority order:
+ * 1. Project-level: {project}/.pi/aliases.json - allows per-project customization
+ * 2. User-level: ~/.pi/agent/aliases.json - global user aliases, survives npm updates
+ * 3. Extension-level: {extensionDir}/aliases.json - bundled defaults
+ */
+function getAliasLocations(cwd: string, extensionDir: string): string[] {
+	return [
+		join(cwd, ".pi", "aliases.json"), // Project-level
+		join(homedir(), ".pi", "agent", "aliases.json"), // User-level
+		join(extensionDir, "aliases.json"), // Extension-level (bundled defaults)
+	];
+}
+
+function loadAliases(cwd: string, extensionDir: string): { aliases: AliasConfig; source?: string; error?: string } {
+	const locations = getAliasLocations(cwd, extensionDir);
+
+	for (const aliasPath of locations) {
+		if (existsSync(aliasPath)) {
+			try {
+				const content = readFileSync(aliasPath, "utf-8");
+				return { aliases: JSON.parse(content), source: aliasPath };
+			} catch (e) {
+				return { aliases: {}, error: `Failed to load ${aliasPath}: ${e instanceof Error ? e.message : e}` };
+			}
+		}
 	}
-	try {
-		const content = readFileSync(aliasPath, "utf-8");
-		return { aliases: JSON.parse(content) };
-	} catch (e) {
-		return { aliases: {}, error: `Failed to load aliases.json: ${e instanceof Error ? e.message : e}` };
-	}
+
+	return { aliases: {} };
 }
 
 const extension: ExtensionFactory = (pi) => {
-	const __dirname = dirname(fileURLToPath(import.meta.url));
-	const { aliases, error: aliasLoadError } = loadAliases(__dirname);
+	// Extension directory is fixed at load time
+	const extensionDir = dirname(fileURLToPath(import.meta.url));
 
 	pi.registerTool({
 		name: "switch_model",
@@ -47,6 +66,8 @@ const extension: ExtensionFactory = (pi) => {
 		}),
 
 		async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+			// Load aliases at execution time to support project-level aliases
+			const { aliases, source: aliasSource, error: aliasLoadError } = loadAliases(ctx.cwd, extensionDir);
 			let models = ctx.modelRegistry.getAvailable();
 			const currentModel = ctx.model;
 
@@ -82,7 +103,7 @@ const extension: ExtensionFactory = (pi) => {
 				const aliasInfo = aliasLoadError
 					? `\n\nWarning: ${aliasLoadError}`
 					: Object.keys(aliases).length > 0
-						? `\n\nAliases: ${Object.keys(aliases).join(", ")}`
+						? `\n\nAliases: ${Object.keys(aliases).join(", ")}${aliasSource ? ` (from ${aliasSource})` : ""}`
 						: "";
 
 				const lines = models.map((m) => {


### PR DESCRIPTION
 ### Summary                                                                                                                
 
 Actually, when installing the extension using *npm*, it fails on getting aliases from README proposed path.
                                                                      
 This PR introduces a priority-based fallback system for model aliases, allowing users to customize aliases at multiple     
 levels with proper precedence.                                                                                             
                                                                                                                            
 ### Changes                                                                                                                
                                                                                                                            
 - Three-tier alias loading with priority order:                                                                            
     1. Project-level: {project}/.pi/aliases.json — per-project customization                                               
     2. User-level: ~/.pi/agent/aliases.json — global user aliases that survive npm update                                  
     3. Extension-level: {extensionDir}/aliases.json — bundled defaults                                                     
 - Load aliases at execution time instead of extension load time, ensuring ctx.cwd is available for project-level           
 resolution                                                                                                                 
 - Report alias source path in the switch_model tool output (e.g., Aliases: cheap, coding (from                             
 /home/user/.pi/agent/aliases.json))                                                                                        
                                                                                                                            
 ### Benefits                                                                                                               
                                                                                                                            
 - Survives updates: User-level aliases in ~/.pi/agent/ won't be overwritten when updating the extension                    
 - Project-specific aliases: Teams can share project aliases via .pi/aliases.json in their repo                             
 - Transparency: Users can see which aliases file is being used     