### PR TITLE
fix: align extension schema imports with pi runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 ### Changed
 - Added project, user, and extension alias-file fallback locations with source reporting in `list`. Thanks to [@pcaro](https://github.com/pcaro) for #1.
 
+### Fixed
+- Migrated extension tool schemas from `@sinclair/typebox` to `typebox` 1.x so packaged installs follow Pi's current extension runtime contract.
+
 ## [0.1.4] - 2026-04-14
 
 ### Fixed

--- a/index.ts
+++ b/index.ts
@@ -1,5 +1,5 @@
-import type { ExtensionFactory } from "@mariozechner/pi-coding-agent";
-import { Type } from "@sinclair/typebox";
+import type { ExtensionFactory } from "@earendil-works/pi-coding-agent";
+import { Type } from "typebox";
 import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";

--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "pi-model-switch",
   "version": "0.1.4",
   "description": "Model switching extension for pi coding agent",
+  "peerDependencies": {
+    "@earendil-works/pi-coding-agent": "*",
+    "typebox": "*"
+  },
   "keywords": ["pi-package", "pi", "pi-coding-agent", "extension", "model", "switch", "llm"],
   "license": "MIT",
   "pi": {


### PR DESCRIPTION
## Summary

Align the extension imports and package metadata with the current Pi runtime contract.

Changes:
- import extension types from `@earendil-works/pi-coding-agent`
- import schemas from `typebox`
- declare both Pi-bundled packages as peer dependencies with `*`
- add the Unreleased changelog entry

## Validation

- `git diff --check`
- focused TypeScript smoke command attempted, blocked because peer dependencies are not installed in the fresh worktree and the repo has no standalone TS config
- fresh exact-head review: No issues found